### PR TITLE
chore: estandariza licencia, seguridad y scripts

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Arcaelas Insiders
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest published major version of @arcaelas/whatsapp receives security updates. Older majors are not patched: upgrade to the current release before reporting.
+
+## Reporting a Vulnerability
+
+Report vulnerabilities privately through [GitHub Security Advisories](https://github.com/arcaelas/whatsapp/security/advisories/new). Do not open public issues or pull requests for security problems: that discloses the flaw before a fix exists.
+
+Include the affected version, a minimal reproduction, and the impact you observed. You will receive an acknowledgement within 72 hours and a resolution or a documented mitigation within 30 days. Once a fix is published, the advisory is disclosed and credits the reporter unless anonymity is requested.
+
+## Dependencies
+
+Dependencies are locked with a committed lockfile and installed with `--frozen-lockfile`; Dependabot alerts are reviewed as they arrive and version bumps land through pull requests to `main`, never by editing the lockfile by hand.
+
+## Release Integrity
+
+Packages are published to npm from the repository state of `main`. The `build/` artifacts are generated at publish time by `prepublishOnly`; no prebuilt or externally produced files are ever included in a release.

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "arcaelas-insiders",
     "javascript"
   ],
-  "license": "ISC",
+  "license": "MIT",
   "main": "./build/cjs/index.js",
   "module": "./build/esm/index.js",
   "name": "@arcaelas/whatsapp",


### PR DESCRIPTION
Licencia MIT unificada, SECURITY.md estandarizado y scripts de publicación canónicos.